### PR TITLE
[RQ-681] - fix: recorder dropping initial events when recording time exceeds max duration

### DIFF
--- a/src/modules/session-recorder/SessionRecorder.ts
+++ b/src/modules/session-recorder/SessionRecorder.ts
@@ -104,16 +104,15 @@ export class SessionRecorder {
       checkoutEveryNms: this.#options.maxDuration,
       emit: (event, isCheckout) => {
         if (isCheckout) {
-          let previousSessionEvents = this.#lastTwoSessionEvents[1];
-          const previousSessionRRWebEvents = previousSessionEvents[RQSessionEventType.RRWEB];
-          const timeElapsedSinceStart = event.timestamp - previousSessionRRWebEvents[0].timestamp;
-
+          const previousSessionEvents = this.#lastTwoSessionEvents[1];
+          const previousSessionRRWebEvents = previousSessionEvents[exports.RQSessionEventType.RRWEB];
+          const timeElapsedInBucket =
+            previousSessionRRWebEvents[previousSessionRRWebEvents.length - 1].timestamp -
+            previousSessionRRWebEvents[0].timestamp;
           // final session duration should be between T and 2T where T is maxDuration
-          if (timeElapsedSinceStart >= 2 * this.#options.maxDuration) {
-            previousSessionEvents = this.#getEmptySessionEvents();
+          if (timeElapsedInBucket > this.#options.maxDuration) {
+            this.#lastTwoSessionEvents = [previousSessionEvents, this.#getEmptySessionEvents()];
           }
-
-          this.#lastTwoSessionEvents = [previousSessionEvents, this.#getEmptySessionEvents()];
         }
 
         this.#addEvent(RQSessionEventType.RRWEB, event);

--- a/src/modules/session-recorder/SessionRecorder.ts
+++ b/src/modules/session-recorder/SessionRecorder.ts
@@ -106,12 +106,14 @@ export class SessionRecorder {
         if (isCheckout) {
           const previousSessionEvents = this.#lastTwoSessionEvents[1];
           const previousSessionRRWebEvents = previousSessionEvents[exports.RQSessionEventType.RRWEB];
-          const timeElapsedInBucket =
-            previousSessionRRWebEvents[previousSessionRRWebEvents.length - 1].timestamp -
-            previousSessionRRWebEvents[0].timestamp;
-          // final session duration should be between T and 2T where T is maxDuration
-          if (timeElapsedInBucket > this.#options.maxDuration) {
-            this.#lastTwoSessionEvents = [previousSessionEvents, this.#getEmptySessionEvents()];
+          if (previousSessionRRWebEvents.length > 1) {
+            const timeElapsedInBucket =
+              previousSessionRRWebEvents[previousSessionRRWebEvents.length - 1].timestamp -
+              previousSessionRRWebEvents[0].timestamp;
+            // final session duration should be between T and 2T where T is maxDuration
+            if (timeElapsedInBucket >= this.#options.maxDuration) {
+              this.#lastTwoSessionEvents = [previousSessionEvents, this.#getEmptySessionEvents()];
+            }
           }
         }
 


### PR DESCRIPTION
It fixes the checkout logic for recorded events when the recording duration exceeds max duration.