### PR TITLE
[RQ-681] fix: ordered DOMContentLoaded events

### DIFF
--- a/src/modules/session-recorder/SessionRecorder.ts
+++ b/src/modules/session-recorder/SessionRecorder.ts
@@ -182,7 +182,15 @@ export class SessionRecorder {
   }
 
   #addEvent(eventType: RQSessionEventType, event: RQSessionEvent): void {
-    this.#lastTwoSessionEvents[1]?.[eventType]?.push(event);
+    // DOMContentLoaded events sometimes come out of order
+    if (event.type === EventType.DomContentLoaded) {
+      const insertIndex = this.#lastTwoSessionEvents[1]?.[eventType]?.findIndex(
+        (arrayEvent) => event.timestamp < arrayEvent.timestamp,
+      );
+      this.#lastTwoSessionEvents[1]?.[eventType]?.splice(insertIndex, 0, event);
+    } else {
+      this.#lastTwoSessionEvents[1]?.[eventType]?.push(event);
+    }
   }
 
   #isCrossDomainFrame(): boolean {

--- a/src/modules/session-recorder/SessionRecorder.ts
+++ b/src/modules/session-recorder/SessionRecorder.ts
@@ -182,15 +182,16 @@ export class SessionRecorder {
   }
 
   #addEvent(eventType: RQSessionEventType, event: RQSessionEvent): void {
+    const previousSessionEvents = this.#lastTwoSessionEvents[1]?.[eventType];
     // DOMContentLoaded events sometimes come out of order
     if (event.type === EventType.DomContentLoaded) {
-      const insertIndex = this.#lastTwoSessionEvents[1]?.[eventType]?.findIndex(
-        (arrayEvent) => event.timestamp < arrayEvent.timestamp,
-      );
-      this.#lastTwoSessionEvents[1]?.[eventType]?.splice(insertIndex, 0, event);
-    } else {
-      this.#lastTwoSessionEvents[1]?.[eventType]?.push(event);
+      const insertIndex = previousSessionEvents?.findIndex((arrayEvent) => event.timestamp < arrayEvent.timestamp);
+      if (insertIndex > -1) {
+        previousSessionEvents?.splice(insertIndex, 0, event);
+        return;
+      }
     }
+    this.#lastTwoSessionEvents[1]?.[eventType]?.push(event);
   }
 
   #isCrossDomainFrame(): boolean {

--- a/src/modules/session-recorder/SessionRecorder.ts
+++ b/src/modules/session-recorder/SessionRecorder.ts
@@ -191,7 +191,7 @@ export class SessionRecorder {
         return;
       }
     }
-    this.#lastTwoSessionEvents[1]?.[eventType]?.push(event);
+    previousSessionEvents?.push(event);
   }
 
   #isCrossDomainFrame(): boolean {

--- a/src/modules/session-recorder/types.ts
+++ b/src/modules/session-recorder/types.ts
@@ -1,4 +1,4 @@
-import { eventWithTime } from '@rrweb/types';
+import { eventWithTime, EventType } from '@rrweb/types';
 
 export interface Environment {
   userAgent: string;
@@ -42,6 +42,7 @@ export enum RQSessionEventType {
 
 export type CommonEventData = {
   frameUrl?: string;
+  type?: EventType;
 };
 
 export type RRWebEventData = CommonEventData & eventWithTime;


### PR DESCRIPTION
Sometimes the `DOMContentLoaded` events come out of order when DOM is inactive. These events are inserted in place in the array.